### PR TITLE
Issue #40 Add empty settings page with message as Moodle/Totara expects it to exist if settings.php does.

### DIFF
--- a/lang/en/applaunch.php
+++ b/lang/en/applaunch.php
@@ -74,11 +74,13 @@ $string['form:app_type:url_help'] = 'This URL will be used to attempt to open th
 
 $string['launch:description'] = 'The application should open automatically. If not, click on the link below.';
 
-$string['setting:manage_app_types'] = "Manage app types";
 $string['setting:addapptype'] = "Add app type";
-$string['setting:newapptype'] = 'New app type';
-$string['setting:editapptype'] = 'Edit app type';
 $string['setting:cantdelete'] = 'Deleting the app type is not allowed. It may be in use by existing activities.';
+$string['setting:editapptype'] = 'Edit app type';
+$string['setting:manage_app_types'] = "Manage app types";
+$string['setting:newapptype'] = 'New app type';
+$string['setting:nosettings'] = 'There are currently no site settings for this plugin. See all settings for this plugin here: '
+        . "<a href=" . '{$a}' . ">App launcher settings</a>";
 
 $string['table:name'] = 'Name';
 $string['table:description'] = 'Description';

--- a/settings.php
+++ b/settings.php
@@ -23,13 +23,23 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use mod_applaunch\plugininfo;
+
 defined('MOODLE_INTERNAL') || die();
 
-$ADMIN->add('modsettings', new admin_category('modapplaunchsettings', new lang_string('pluginname', 'applaunch')));
+$ADMIN->add('modsettings', new admin_category(plugininfo::SETTINGS_CATEGORY, new lang_string('pluginname', 'applaunch')));
+
+// Add empty page with message while we don't have any settings.
+$settings->add(new admin_setting_heading('main_heading',
+        new lang_string('settings'),
+        new lang_string('setting:nosettings', 'applaunch',
+                (new \moodle_url('/admin/category.php', array('category' => plugininfo::SETTINGS_CATEGORY)))->out())));
+$ADMIN->add(plugininfo::SETTINGS_CATEGORY, $settings);
+
 $settings = null; // Tell core we have managed the settings pages ourselves.
 
 if (has_capability('mod/applaunch:manageapptypes', context_system::instance())) {
-    $ADMIN->add(\mod_applaunch\plugininfo::SETTINGS_CATEGORY,
+    $ADMIN->add(plugininfo::SETTINGS_CATEGORY,
         new admin_externalpage(
             'mod_applaunch/app_type',
             get_string('setting:manage_app_types', 'applaunch'),


### PR DESCRIPTION
There were a few settings link still throwing an error, because the link is hard coded in some places including `/admin/modules.php`. So this is a short stop. It allows the user to return to the main settings category page that includes external pages.